### PR TITLE
Added auto-schema naming option.

### DIFF
--- a/ldms/scripts/examples/tx2mon
+++ b/ldms/scripts/examples/tx2mon
@@ -1,13 +1,28 @@
 export plugname=tx2mon
 portbase=61086
-LDMSD -p prolog.sampler 1 2
-LDMSD -p prolog.sampler -p prolog.store3 3
+VGARGS="--leak-check=full --track-origins=yes"
+DAEMONS $(seq 1 6)
+vgon
+LDMSD -p prolog.sampler 1
+LDMSD 2 3 4 5
+LDMSD -p prolog.sampler 6
+vgoff
 MESSAGE ldms_ls on host 1:
 LDMS_LS 1 -v
 MESSAGE ldms_ls on host 2:
-LDMS_LS 2 -l
+LDMS_LS 2 -v
 MESSAGE ldms_ls on host 3:
-LDMS_LS 3
+LDMS_LS 3 -v
+MESSAGE ldms_ls on host 4:
+LDMS_LS 4 -v
+MESSAGE ldms_ls on host 5:
+LDMS_LS 5 -v
+MESSAGE ldms_ls on host 6:
+LDMS_LS 6 -l
+LDMS_LS 6 -v
 SLEEP 5
-KILL_LDMSD `seq 3`
+KILL_LDMSD `seq 6`
 file_created $STOREDIR/node/$testname
+file_created $STOREDIR/node/${testname}_01
+file_created $STOREDIR/node/${testname}_10
+file_created $STOREDIR/node/${testname}_11

--- a/ldms/scripts/examples/tx2mon.2
+++ b/ldms/scripts/examples/tx2mon.2
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} schema=${testname} instance=localhost${i}/${testname} component_id=${i} auto-schema=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.3
+++ b/ldms/scripts/examples/tx2mon.3
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 array=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.4
+++ b/ldms/scripts/examples/tx2mon.4
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 extra=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.5
+++ b/ldms/scripts/examples/tx2mon.5
@@ -1,0 +1,3 @@
+load name=${plugname}
+config name=${plugname} producer=localhost${i} instance=localhost${i}/${testname} component_id=${i} auto-schema=1 array=1 extra=1
+start name=${plugname} interval=1000000 offset=0

--- a/ldms/scripts/examples/tx2mon.6
+++ b/ldms/scripts/examples/tx2mon.6
@@ -1,0 +1,39 @@
+load name=store_csv
+config name=store_csv path=${STOREDIR} altheader=0
+
+prdcr_add name=localhost1 host=${HOST} type=active xprt=${XPRT} port=${port1} interval=10000000
+prdcr_start name=localhost1
+
+prdcr_add name=localhost2 host=${HOST} type=active xprt=${XPRT} port=${port2} interval=10000000
+prdcr_start name=localhost2
+
+prdcr_add name=localhost3 host=${HOST} type=active xprt=${XPRT} port=${port3} interval=10000000
+prdcr_start name=localhost3
+
+prdcr_add name=localhost4 host=${HOST} type=active xprt=${XPRT} port=${port4} interval=10000000
+prdcr_start name=localhost4
+
+prdcr_add name=localhost5 host=${HOST} type=active xprt=${XPRT} port=${port5} interval=10000000
+prdcr_start name=localhost5
+
+updtr_add name=allhosts interval=1000000 offset=100000
+updtr_prdcr_add name=allhosts regex=.*
+updtr_start name=allhosts
+
+# schemas are testname, tx2mon_10, tx2mon_01, tx2mon_11
+strgp_add name=store_${testname} plugin=store_csv schema=${testname} container=node
+strgp_prdcr_add name=store_${testname} regex=.*
+strgp_start name=store_${testname}
+
+strgp_add name=store_${testname}_11 plugin=store_csv schema=${testname}_11 container=node
+strgp_prdcr_add name=store_${testname}_11 regex=.*
+strgp_start name=store_${testname}_11
+
+strgp_add name=store_${testname}_10 plugin=store_csv schema=${testname}_10 container=node
+strgp_prdcr_add name=store_${testname}_10 regex=.*
+strgp_start name=store_${testname}_10
+
+strgp_add name=store_${testname}_01 plugin=store_csv schema=${testname}_01 container=node
+strgp_prdcr_add name=store_${testname}_01 regex=.*
+strgp_start name=store_${testname}_01
+

--- a/ldms/src/sampler/tx2mon/Makefile.am
+++ b/ldms/src/sampler/tx2mon/Makefile.am
@@ -23,11 +23,9 @@ AM_LDFLAGS = @OVIS_LIB_ABS@
 COMMON_LIBADD = -lsampler_base -lldms @LDFLAGS_GETTIME@ -lovis_util -lcoll
 
 if ENABLE_TX2MON
-libtx2mon_la_SOURCES = tx2mon.c tx2mon.h
-libtx2mon_la_LIBADD = $(COMMON_LIBADD) tx2mon_cli.c
+libtx2mon_la_SOURCES = tx2mon_cli.c tx2mon.c tx2mon.h
+libtx2mon_la_LIBADD = $(COMMON_LIBADD)
 pkglib_LTLIBRARIES = libtx2mon.la
 dist_man7_MANS = Plugin_tx2mon.man
-# in particular we want to avoid hard coding paths into plugins
-#libtx2mon_la_CFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 endif
 

--- a/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
+++ b/ldms/src/sampler/tx2mon/Plugin_tx2mon.man
@@ -18,18 +18,19 @@ The tx2mon plugin provides cpu and system-on-chip information from /sys/bus/plat
 The standard options from sampler_base apply. The specific options for tx2mon are listed here
 .TP
 .BR config
-name=tx2mon <standard options> [array=<bool>] [auto-schema=<bool>]
+name=tx2mon <standard options> [array=<bool>] [extra=<bool>] [auto-schema=<bool>]
 .br
 .RS
 .TP
 schema=<schema>
 .br
-Optional schema name. It is required by most storage backends that the same sampler on different nodes with different metric subsets needs to have a unique schema name. Use auto-schema=1 instead of schema to automatically meet the backend requirement.
+Optional schema name. It is required by most storage backends that the same sampler on different nodes with different metric subsets needs to have a unique schema name. Use auto-schema=1 instead of or in addition to schema to automatically meet the backend requirement.
 .TP
 auto-schema=<bool>
 .br
 If true, change the schema name to tx2mon_$X, where $X will be
-a unique hex value derived from the data selection options. If both schema and auto-schema are given, for backward-compatibility auto-schema is ignored for the tx2mon plugin.
+a unique value derived from the data selection options. If both schema and auto-schema=1 are given, the
+schema name given is used as the base instead of "tx2mon".
 .TP
 array=<bool>
 .br
@@ -51,52 +52,66 @@ node                 Number of socket i from
                      /sys/bus/platform/devices/tx2mon/node<i>_raw
 .fi
 
+.PP
 The metrics listed here are named as their respective fields in tx2mon/mc_oper_region.h. Where applicable, metrics are converted to the units listed here from the raw values.
 .nf
-counter            		Snapshot value of the cpu. Reported as a string
-                   		integer.
-freq_cpu[MAX_CPUS_PER_SOC]   	Frequency reading of each core. Set with <array=true>.
-<freq_cpu_min>		   	Minimum value found in freq_cpu Set with <array=false>.
-<freq_cpu_max>         		Maximum value found in freq_cpu.Set with <array=false>.
-tmon_cpu[MAX_CPUS_PER_SOC]   	Temperature reading of each core. (deg. C). Set with <array=true>
-<tmon_cpu_min>			Minimum value found in tmon_cpu. (deg. C) Set with <array=false>.
-<tmon_cpu_max>		        Maximum value found in tmon_cpu. (deg. C) Set with <array=false>.
-tmon_soc_avg       		Average temperature on the SoC. (deg. C)
-pwr_core           		Power consumed by all cores on the SoC. (Watt).
-pwr_sram           		Power consumed by all internal SRAM on the SoC. (Watt).
-pwr_mem            		Power consumed by the LLC ring on the SoC. (Watt)
-pwr_soc            		Power consumed by SoC blocks that are misc. (Watt)
-v_core             		Voltage consumed by all cores on the SoC. (V)
-v_sram             		Voltage consumed by all internal SRAM on the SoC. (V)
-v_mem              		Voltage consumed by the LLC ring on the SoC. (V)
-v_soc              		Voltage consumed by SoC blocks that are misc. (V).
-active_evt         		Provides a list of active events that are causing 
-                   		throttling. (V).
-Temperature	   		Active event with a bit flag where 1 is true.
-Power		   		Active event with a bit flag where 1 is true.
-External	   		Active event with a bit flag where 1 is true.
-Unk3		   		Active event with a bit flag where 1 is true.
-Unk4		   		Active event with a bit flag where 1 is true.
-Unk5		   		Active event with a bit flag where 1 is true.
-temp_evt_cnt      		Total number of temperature events.
-pwr_evt_cnt        		Total number of power events.
-ext_evt_cnt        		Total number of exteral events.
-temp_throttle_ms   		Time duration of all temperature events in ms.
-pwr_throttle_ms    		Time duration of all power events in ms.
-ext_throttle_ms    		Time duration of all external events in ms.
+counter        Snapshot counter of the cpu.
 
-Set following metrics with <extra=true>:
-<temp_abs_max>                  Absolute maximum limit of temperature beyond
-                                which the SoC will throttle voltage and frequency.
-<temp_soft_thresh>              Soft limit of temperature beyond which the SoC will
-                                throttle voltage and frequency down.
-<temp_hard_thresh>              Hard limit of temperature beyond which the SoC will
-                                throttle voltage and frequency down.
-<freq_mem_net>                  Frequency reading of the SoC and ring connection.
-<freq_max>                      Maximum limit of SoC frequency. Depends on the SKU.
-<freq_min>                      Minimum limit of SoC frequency. Depends on the SKU.
-<freq_socs>                     Internal block frequency of SOC South clock. (Mhz)
-<freq_socn>                     Internal block frequency of SOC North clock. (Mhz)
+.PP
+Include the following metrics when array=true:
+.nf
+freq_cpu[]     Frequency reading of each core.
+tmon_cpu[]     Temperature reading of each core. (deg. C).
+.fi
+.PP
+Include the following metrics when array=false:
+.nf
+freq_cpu_min   Minimum value found in freq_cpu. 
+freq_cpu_max   Maximum value found in freq_cpu. 
+tmon_cpu_min   Minimum value found in tmon_cpu. (deg. C) 
+tmon_cpu_max   Maximum value found in tmon_cpu. (deg. C)
+.fi
+.PP
+Include the following metrics unconditionally:
+.nf
+tmon_soc_avg   Average temperature on the SoC. (deg. C)
+pwr_core       Power consumed by all cores on the SoC. (Watt).
+pwr_sram       Power consumed by all internal SRAM on the SoC. (Watt).
+pwr_mem        Power consumed by the LLC ring on the SoC. (Watt)
+pwr_soc        Power consumed by SoC blocks that are misc. (Watt)
+v_core         Voltage consumed by all cores on the SoC. (V)
+v_sram         Voltage consumed by all internal SRAM on the SoC. (V)
+v_mem          Voltage consumed by the LLC ring on the SoC. (V)
+v_soc          Voltage consumed by SoC blocks that are misc. (V).
+active_evt     Provides a bit list of active events that are causing throttling.
+Temperature    Active event with a bit flag where 1 is true.
+Power          Active event with a bit flag where 1 is true.
+External       Active event with a bit flag where 1 is true.
+Unk3           Active event with a bit flag where 1 is true.
+Unk4           Active event with a bit flag where 1 is true.
+Unk5           Active event with a bit flag where 1 is true.
+temp_evt_cnt   Total number of temperature events.
+pwr_evt_cnt       Total number of power events.
+ext_evt_cnt       Total number of exteral events.
+temp_throttle_ms  Time duration of all temperature events in ms.
+pwr_throttle_ms   Time duration of all power events in ms.
+ext_throttle_ms   Time duration of all external events in ms.
+.fi
+
+.PP
+Include the following metrics with extra=true:
+.nf
+temp_abs_max       Absolute maximum limit of temperature beyond
+                   which the SoC will throttle voltage and frequency.
+temp_soft_thresh   Soft limit of temperature beyond which the SoC will
+                   throttle voltage and frequency down.
+temp_hard_thresh   Hard limit of temperature beyond which the SoC will
+                   throttle voltage and frequency down.
+freq_mem_net       Frequency reading of the SoC and ring connection.
+freq_max           Maximum limit of SoC frequency. Depends on the SKU.
+freq_min           Minimum limit of SoC frequency. Depends on the SKU.
+freq_socs          Internal block frequency of SOC South clock. (Mhz)
+freq_socn          Internal block frequency of SOC North clock. (Mhz)
 .fi
 
 .SH EXAMPLES
@@ -117,6 +132,8 @@ tx2mon reports on the sensors monitored by the on-chip management controller.
 Some of the on-chip components (such as the IO blocks) do not have sensors
 and therefore the voltage and power measurements of these blocks are not
 provided by tx2mon.
+
+The current generated schema names are: tx2mon, tx2mon_11, tx2mon_01, and tx2mon_10, where the suffix is derived as _(array)(extra). "tx2mon" is used when tx2mon_00 would occur.
 
 .SH SEE ALSO
 ldmsd(8), ldms_sampler_base

--- a/ldms/src/sampler/tx2mon/tx2mon_cli.c
+++ b/ldms/src/sampler/tx2mon/tx2mon_cli.c
@@ -2,37 +2,26 @@
 /*
  * Copyright (c) 2018 Marvell International Ltd.
  */
-
-/*
- *  Copyright [2020] Hewlett Packard Enterprise Development LP
- * 
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for 
- * more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
- * this program; if not, write to:
- * 
- *   Free Software Foundation, Inc.
- *   51 Franklin Street, Fifth Floor
- *   Boston, MA 02110-1301, USA.
+/* Extracted from tx2mon.c in
+ * https://github.com/jchandra-cavm/tx2mon/
  */
-static int read_node(struct cpu_info *d)
+#include "tx2mon.h"
+#include "assert.h"
+#include "stdlib.h"
+#include <sys/types.h>
+#include <unistd.h>
+
+int tx2mon_read_node(struct cpu_info *d)
 {
         assert(d!=NULL);
         int rv;
         struct mc_oper_region *op = &d->mcp;
         rv = lseek(d->fd, 0, SEEK_SET);
-        if (rv < 0)
+        if (rv == (off_t) -1)
                return rv;
         rv = read(d->fd, op, sizeof(*op));
         if (rv < sizeof(*op))
-                return rv;
+                return 2;
         if (CMD_STATUS_READY(op->cmd_status) == 0)
                 return 0;
         if (CMD_VERSION(op->cmd_status) > 0)


### PR DESCRIPTION
Code, test, and man page nit cleanup.
Got rid of redundant/unused definitions.
Got rid of extra debug statements.
Reordered functions to reduce forward definitions needed.
Fixed visual misalignment of braces.
Added test of all schema permutations.
Fixed include of cli .c file.